### PR TITLE
sf::st_geometry() en remplacement $geometry

### DIFF
--- a/R/line_tools.R
+++ b/R/line_tools.R
@@ -4,7 +4,7 @@
 #' and ensure getting topologically valid network.
 #'
 #' @param roads  multiples lines (sf format)
-#' @param tolerance numeric. Tolerance value used to snap the road endings
+#' @param tolerance numeric. Tolerance value in distance unit used to snap the road endings
 #'
 #' @return The same object provided in input but with corrected ending such as roads are connected.
 #' @export
@@ -23,26 +23,26 @@ st_snap_lines = function(roads, tolerance = 8)
   u <- do.call(c, u)
   sf::st_crs(u) <- sf::st_crs(roads)
 
-  v <- sf::st_is_within_distance(u, start, 5)
+  v <- sf::st_is_within_distance(u, start, 5/8*tolerance)
   for (i in seq_along(v))
   {
     ids <- v[[i]]
     for(j in ids)
     {
-      roads[j,]$geometry[[1]][1, 1] <- u[i][[1]][[1]]
-      roads[j,]$geometry[[1]][1, 2] <- u[i][[1]][[2]]
+      sf::st_geometry(roads[j,])[[1]][1, 1] <- u[i][[1]][[1]]
+      sf::st_geometry(roads[j,])[[1]][1, 2] <- u[i][[1]][[2]]
     }
   }
 
-  w <- st_is_within_distance(u, end, 5)
+  w <- st_is_within_distance(u, end, 5/8*tolerance)
   for (i in seq_along(w))
   {
     ids <- w[[i]]
     for(j in ids)
     {
-      n <- nrow(roads[j,]$geometry[[1]])
-      roads[j,]$geometry[[1]][n, 1] <- u[i][[1]][[1]]
-      roads[j,]$geometry[[1]][n, 2] <- u[i][[1]][[2]]
+      n <- nrow(sf::st_geometry(roads[j,])[[1]])
+      sf::st_geometry(roads[j,])[[1]][n, 1] <- u[i][[1]][[1]]
+      sf::st_geometry(roads[j,])[[1]][n, 2] <- u[i][[1]][[2]]
     }
   }
 


### PR DESCRIPTION
Si la colonne contenant les géométries dans l'object sf ne s'appelle pas `geometry`, la fonction `st_snap_lines()` échouait avec l'erreur suivante:
```
Error in roads[j, ]$geometry[[1]][1, 1] <- u[i][[1]][[1]] : 
  incorrect number of subscripts on matrix
```
Dans mon jeu de données, la colonne de géométrie utilisait `geom` causant une erreur si on cherchait `geometry`. En utilisant `sf::st_geometry()` on évite la confusion possible.

J'ai aussi précisé que la variable de tolérance est en unité de distance.

Finalement, j'ai rendu dynamique la tolérance de `sf::st_is_within_distance()` lors de la jointure pour qu'elle soit fonction de la tolérance principale. À mon avis, si en souhaite une tolérance de 15 m en entrée au lieu du 8 m par défaut, on accepte alors probablement que le point milieu soit potentiellement à plus de 5 m des extrémités, soit dans ce cas-ci à un maximum de 9.375 m.