### PR TITLE
Avertissement si aucun snap possible

### DIFF
--- a/R/line_tools.R
+++ b/R/line_tools.R
@@ -21,6 +21,12 @@ st_snap_lines = function(roads, tolerance = 8)
   u <- lapply(u, function(x) { ends[x] })
   u <- lapply(u, function(x) { sf::st_sfc(sf::st_point(colMeans(sf::st_coordinates(x)))) })
   u <- do.call(c, u)
+
+  if (is.null(u)) {
+    warning(glue::glue("No roads could be snapped with the tolerance used ({tolerance} m). Original roads returned."), call. = FALSE)
+    return(roads)
+  }
+
   sf::st_crs(u) <- sf::st_crs(roads)
 
   v <- sf::st_is_within_distance(u, start, 5)


### PR DESCRIPTION
Si aucun snap n'est possible dans la couche, l'erreur suivante est soulevée:
```
Error in UseMethod("st_crs<-") : 
  no applicable method for 'st_crs<-' applied to an object of class "NULL"
```

Maintenant, les routes originales sont retournées et l'avertissement suivant est affiché:
```
Warning message:
No roads could be snapped with the tolerance used (8 m). Original roads returned.
```
