### PR TITLE
Avertissement si les deux extrémités d'un segment ont été snappés ensemble

### DIFF
--- a/R/line_tools.R
+++ b/R/line_tools.R
@@ -52,6 +52,15 @@ st_snap_lines = function(roads, tolerance = 8)
     }
   }
 
+  end   <- lwgeom::st_endpoint(roads)
+  start <- lwgeom::st_startpoint(roads)
+  idx_idem <- which(end == start)
+
+  if (length(idx_idem)) {
+    idx_roads <- glue::glue_collapse(idx_idem, ", ")
+    warning(glue::glue("The following roads had both of their ends being snapped together: {idx_roads}"), call. = FALSE)
+  }
+
   return(roads)
 }
 


### PR DESCRIPTION
Cas pouvant se produire si les deux extrémités d'un segment se situent à moins de `tolerance` d'un point milieu de snapping trouvé dans `st_snap_lines()`. Dans un cas où les géométries 3 et 7 subiraient ce sort, le message suivant serait émis:

```
Warning message:
The following roads had both of their ends being snapped together: 3, 7
```

Normalement ça devrait être très très rare, mais je suis certain que ça arrivera dans notre couche provinciale de routes.