### PR TITLE
S'assure d'un CRS projeté pour les routes

### DIFF
--- a/R/line_tools.R
+++ b/R/line_tools.R
@@ -23,7 +23,7 @@ st_snap_lines = function(roads, tolerance = 8)
   u <- do.call(c, u)
 
   if (is.null(u)) {
-    dist_unit <- st_crs(u)$units
+    dist_unit <- sf::st_crs(u)$units
     warning(glue::glue("No roads could be snapped with the tolerance used ({tolerance} {dist_unit}). Original roads returned."), call. = FALSE)
     return(roads)
   }

--- a/R/line_tools.R
+++ b/R/line_tools.R
@@ -23,7 +23,8 @@ st_snap_lines = function(roads, tolerance = 8)
   u <- do.call(c, u)
 
   if (is.null(u)) {
-    warning(glue::glue("No roads could be snapped with the tolerance used ({tolerance} m). Original roads returned."), call. = FALSE)
+    dist_unit <- st_crs(u)$units
+    warning(glue::glue("No roads could be snapped with the tolerance used ({tolerance} {dist_unit}). Original roads returned."), call. = FALSE)
     return(roads)
   }
 

--- a/R/mffp_road.R
+++ b/R/mffp_road.R
@@ -89,12 +89,11 @@ measure_road = function(ctg, road, dtm, water = NULL, param = mffproads_default_
   if (nrow(road) > 1) stop("Expecting a single LINESTRING", call. = FALSE)
   if (!methods::is(ctg, "LAScatalog")) stop("Expecting a LAScatalog", call. = FALSE)
   if (!is.null(water)) { if (any(!sf::st_geometry_type(water) %in% c("MULTIPOLYGON", "POLYGON"))) stop("Expecting POLYGON geometry type for 'water'", call. = FALSE) }
+  if (sf::st_is_longlat(road)) stop("Expecting a projected CRS for 'road' but geographic found insteand.", call. = FALSE)
   if (!isFALSE(dots$Windex)) { if (!lidR::is.indexed(ctg)) message("No spatial index for LAS/LAZ files in this collection.") }
   if (getOption("MFFProads.debug.progress")) cat("Progress: ")
 
-  dist_unit <- st_crs(road)$units
-  if (is.null(dist_unit)) stop("Expecting a projected CRS for 'road'", call. = FALSE)
-  
+  dist_unit <- sf::st_crs(road)$units
   length_min = 4*param$extraction$section_length
 
   # This is the metrics we will estimate on the road. We generate a default output in case we should exit early

--- a/R/mffp_road.R
+++ b/R/mffp_road.R
@@ -27,6 +27,8 @@
 #' library(lidR)
 #' library(sf)
 #' library(raster)
+#' library(mapview)
+#' library(leaflet)
 #'
 #' dir  <- system.file("extdata", "", package="MFFProads")
 #' road <- system.file("extdata", "road_971487.gpkg", package="MFFProads")
@@ -35,6 +37,7 @@
 #' road <- st_read(road, quiet = TRUE)
 #' dtm  <- raster(dtm)
 #' crs  <- st_crs(road)
+#' crs(dtm)  <- crs
 #'
 #' # Voluntarily add more error to the road
 #' st_geometry(road) <- st_geometry(road) + st_sfc(st_point(c(-8, 0)))
@@ -89,6 +92,9 @@ measure_road = function(ctg, road, dtm, water = NULL, param = mffproads_default_
   if (!isFALSE(dots$Windex)) { if (!lidR::is.indexed(ctg)) message("No spatial index for LAS/LAZ files in this collection.") }
   if (getOption("MFFProads.debug.progress")) cat("Progress: ")
 
+  dist_unit <- st_crs(road)$units
+  if (is.null(dist_unit)) stop("Expecting a projected CRS for 'road'", call. = FALSE)
+  
   length_min = 4*param$extraction$section_length
 
   # This is the metrics we will estimate on the road. We generate a default output in case we should exit early
@@ -120,14 +126,14 @@ measure_road = function(ctg, road, dtm, water = NULL, param = mffproads_default_
   # Cut the road is too long or is loop
   len <- as.numeric(sf::st_length(road))
   if (len < length_min) {
-    warning(glue::glue("Too short (< {length_min} m) road to compute anything. Original road returned."), call. = FALSE)
+    warning(glue::glue("Too short (< {length_min} {dist_unit}) road to compute anything. Original road returned."), call. = FALSE)
     verbose("Done\n") ; cat("\n")
     return(new_road)
   }
 
   cut <- floor(len/param[["extraction"]][["road_max_len"]])
-  if (cut > 0) { message(sprintf("Long road detected. Splitting the roads in %d chunks of %d m to process.", cut+1, round(sf::st_length(road)/(cut+1)))) }
-  if (cut == 0 && st_is_loop(road)) { message(sprintf("Loop detected. Splitting the roads in 2 chunks of %d m to process.", round(sf::st_length(road)/2,0))) ; cut = 1 }
+  if (cut > 0) { message(sprintf("Long road detected. Splitting the roads in %d chunks of %d %s to process.", cut+1, round(sf::st_length(road)/(cut+1)), dist_unit)) }
+  if (cut == 0 && st_is_loop(road)) { message(sprintf("Loop detected. Splitting the roads in 2 chunks of %d %s to process.", round(sf::st_length(road)/2,0), dist_unit)) ; cut = 1 }
 
   if (cut > 0)
   {
@@ -189,7 +195,7 @@ measure_road = function(ctg, road, dtm, water = NULL, param = mffproads_default_
 
     if (as.numeric(sf::st_length(res)) < length_min)
     {
-      warning(glue::glue("The computed road is too short (< {length_min} m) to compute anything. Original road returned."), call. = FALSE)
+      warning(glue::glue("The computed road is too short (< {length_min} {dist_unit}) to compute anything. Original road returned."), call. = FALSE)
       new_road$ROADWIDTH     <- NA
       new_road$DRIVABLEWIDTH <- NA
       new_road$RIGHTOFWAY    <- NA

--- a/R/mffp_road.R
+++ b/R/mffp_road.R
@@ -89,7 +89,7 @@ measure_road = function(ctg, road, dtm, water = NULL, param = mffproads_default_
   if (nrow(road) > 1) stop("Expecting a single LINESTRING", call. = FALSE)
   if (!methods::is(ctg, "LAScatalog")) stop("Expecting a LAScatalog", call. = FALSE)
   if (!is.null(water)) { if (any(!sf::st_geometry_type(water) %in% c("MULTIPOLYGON", "POLYGON"))) stop("Expecting POLYGON geometry type for 'water'", call. = FALSE) }
-  if (sf::st_is_longlat(road)) stop("Expecting a projected CRS for 'road' but geographic found insteand.", call. = FALSE)
+  if (sf::st_is_longlat(road)) stop("Expecting a projected CRS for 'road' but geographic CRS found instead.", call. = FALSE)
   if (!isFALSE(dots$Windex)) { if (!lidR::is.indexed(ctg)) message("No spatial index for LAS/LAZ files in this collection.") }
   if (getOption("MFFProads.debug.progress")) cat("Progress: ")
 


### PR DESCRIPTION
S'assure que la couche de chemin utilise un CRS projeté et non géographique car sinon la mesure de tolérance n'a plus de sens. J'ajoute la vérification, car si logiquement une couche de chemin a surtout du sens avec un CRS projeté, il m'est déjà arrivé d'en voir avec un CRS géographique. Le message suivant est affiché en cas d'erreur:
```
Error: Expecting a projected CRS for 'road'
```
J'ai aussi changé quelques messages d'avertissement utilisant `m` comme unité de distance pour que ce soit plutôt la valeur de `st_crs(road)$units` qui soit utilisé. Comme ça, le message sera cohérant si le CRS utilise des pieds comme unité.